### PR TITLE
rpyloader --help now calls itself "rpyloader"

### DIFF
--- a/po/rpyutils.pot
+++ b/po/rpyutils.pot
@@ -20,7 +20,7 @@ msgid "Wrong option."
 msgstr ""
 
 #: rpyloader:64
-msgid "Usage: pyLoader.py -[htif:d:l:] --[help, file, device, terminal, debug-level]"
+msgid "Usage: %(myName)s -[htif:d:l:] --[help, file, device, terminal, debug-level]"
 msgstr ""
 
 #: rpyloader:65

--- a/rpyloader
+++ b/rpyloader
@@ -4,6 +4,7 @@
 '''
 rpyloader - Load hex programs on your robot
 Copyright (C) 2011 Scirocco <rpyutils@t-online.de>
+Copyright (C) 2016 Benedikt Wildenhain <rpyutils@benedikt-wildenhain.de>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -61,7 +62,7 @@ def getargs(argv):
             debuglevel = int(arg)
             
 def usage():
-    print(_("Usage: pyLoader.py -[htif:d:l:] --[help, file, device, terminal, debug-level]"))
+    print(_("Usage: %(myName)s -[htif:d:l:] --[help, file, device, terminal, debug-level]") % { 'myName': __file__ })
     print(_("-h, --help            show this help dialog"))
     print(_("-f, --file   [file]   specify a filename"))
     print(_("-d, --device [device] select other device than /dev/ttyUSB0"))


### PR DESCRIPTION
The help option previously used "pyLoader.py" as program name, now it uses the actual file name (via __file__) to print the correct name.